### PR TITLE
Save subject versions as ansible facts

### DIFF
--- a/ansible/ami.yml
+++ b/ansible/ami.yml
@@ -9,45 +9,23 @@
     - journald-rate-limits
     - flog
 
-    - role: filebeat
-      action: install
-      version: "{{ filebeat_version }}"
-
     - role: file_test_server
       action: install
-
-    - role: fluentbit
-      action: install
-      version: "{{ fluentbit_version }}"
-
-    - role: fluentd
-      action: install
-      version: "{{ fluentd_version }}"
 
     - role: http_test_server
       action: install
 
-    - role: logstash
-      action: install
-      version: "{{ logstash_version }}"
-
     - role: profiling
       action: install
 
-    - role: splunk_heavy_forwarder
+    - role: subjects
       action: install
-      version_with_hash: "{{ splunk_heavy_forwarder_version }}"
 
-    - role: splunk_universal_forwarder
-      action: install
-      version_with_hash: "{{ splunk_universal_forwarder_version }}"
+    - role: subjects
+      action: save_facts
 
     - role: tcp_test_server
       action: install
-
-    - role: vector
-      action: install
-      version: "{{ vector_version }}"
 
     - role: docker
       action: install

--- a/ansible/roles/file_test_server/tasks/reset.yml
+++ b/ansible/roles/file_test_server/tasks/reset.yml
@@ -1,3 +1,5 @@
 ---
+- include: "stop.yml"
+
 - name: Reset test file state
   shell: rm -rf {{ test_file_path }}

--- a/ansible/roles/filebeat/tasks/reset.yml
+++ b/ansible/roles/filebeat/tasks/reset.yml
@@ -1,0 +1,2 @@
+---
+- include: "stop.yml"

--- a/ansible/roles/fluentd/tasks/reset.yml
+++ b/ansible/roles/fluentd/tasks/reset.yml
@@ -1,0 +1,2 @@
+---
+- include: "stop.yml"

--- a/ansible/roles/http_test_server/tasks/reset.yml
+++ b/ansible/roles/http_test_server/tasks/reset.yml
@@ -1,3 +1,5 @@
 ---
+- include: "stop.yml"
+
 - name: Reset http test server state
   shell: rm -rf /tmp/http_test_server_summary.json

--- a/ansible/roles/subjects/save_facts.yml
+++ b/ansible/roles/subjects/save_facts.yml
@@ -1,0 +1,1 @@
+save_facts.yml

--- a/ansible/roles/subjects/tasks/install.yml
+++ b/ansible/roles/subjects/tasks/install.yml
@@ -1,0 +1,35 @@
+---
+- include_role: filebeat
+  vars:
+    action: install
+    version: "{{ filebeat_version }}"
+
+- include_role: fluentbit
+  vars:
+    action: install
+    version: "{{ fluentbit_version }}"
+
+- include_role: fluentd
+  vars:
+    action: install
+    version: "{{ fluentd_version }}"
+
+- include_role: logstash
+  vars:
+    action: install
+    version: "{{ logstash_version }}"
+
+- include_role: splunk_heavy_forwarder
+  vars:
+    action: install
+    version_with_hash: "{{ splunk_heavy_forwarder_version }}"
+
+- include_role: splunk_universal_forwarder
+  vars:
+    action: install
+    version_with_hash: "{{ splunk_universal_forwarder_version }}"
+
+- include_role: vector
+  vars:
+    action: install
+    version: "{{ vector_version }}"

--- a/ansible/roles/subjects/tasks/main.yml
+++ b/ansible/roles/subjects/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include: "{{ action }}.yml"

--- a/ansible/roles/subjects/tasks/reset.yml
+++ b/ansible/roles/subjects/tasks/reset.yml
@@ -1,0 +1,28 @@
+---
+- include_role: filebeat
+  vars:
+    action: reset
+
+- include_role: fluentbit
+  vars:
+    action: reset
+
+- include_role: fluentd
+  vars:
+    action: reset
+
+- include_role: logstash
+  vars:
+    action: reset
+
+- include_role: splunk_heavy_forwarder
+  vars:
+    action: reset
+
+- include_role: splunk_universal_forwarder
+  vars:
+    action: reset
+
+- include_role: vector
+  vars:
+    action: reset

--- a/ansible/roles/subjects/tasks/save_facts.yml
+++ b/ansible/roles/subjects/tasks/save_facts.yml
@@ -1,0 +1,9 @@
+---
+- name: create directory for ansible custom facts
+  file: state=directory recurse=yes path=/etc/ansible/facts.d
+
+- name: install subject facts
+  copy: src=subject_versions.fact dest=/etc/ansible/facts.d
+
+- name: re-read facts after adding custom fact
+  setup: filter=ansible_local

--- a/ansible/roles/subjects/templates/subject_versions.fact
+++ b/ansible/roles/subjects/templates/subject_versions.fact
@@ -1,0 +1,8 @@
+[subjects]
+filebeat_version={{ filebeat_version }}
+fluentbit_version={{ fluentbit_version }}
+fluentd_version={{ fluentd_version }}
+logstash_version={{ logstash_version }}
+splunk_heavy_forwarder_version={{ splunk_heavy_forwarder_version }}
+splunk_universal_forwarder_version={{ splunk_universal_forwarder_version }}
+vector_version={{ vector_version }}

--- a/ansible/roles/tcp_test_server/tasks/reset.yml
+++ b/ansible/roles/tcp_test_server/tasks/reset.yml
@@ -1,3 +1,5 @@
 ---
+- include: "stop.yml"
+
 - name: Reset tcp test server state
   shell: rm -rf /tmp/tcp_test_server_summary.json

--- a/cases/disk_buffer_performance/ansible/reset.yml
+++ b/cases/disk_buffer_performance/ansible/reset.yml
@@ -1,21 +1,11 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
-      action: reset
-    - role: vector
+    - role: subjects
       action: reset
 
 - hosts: '{{ test_namespace }}:&tag_TestRole_consumer'
   become: true
   roles:
     - role: tcp_test_server
-      action: stop
+      action: reset

--- a/cases/disk_buffer_persistence_correctness/ansible/reset.yml
+++ b/cases/disk_buffer_persistence_correctness/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset

--- a/cases/docker_partial_events_merging_correctness/ansible/reset.yml
+++ b/cases/docker_partial_events_merging_correctness/ansible/reset.yml
@@ -1,5 +1,5 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: vector
+    - role: subjects
       action: reset

--- a/cases/file_rotate_create_correctness/ansible/reset.yml
+++ b/cases/file_rotate_create_correctness/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset

--- a/cases/file_rotate_truncate_correctness/ansible/reset.yml
+++ b/cases/file_rotate_truncate_correctness/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset

--- a/cases/file_to_tcp_performance/ansible/reset.yml
+++ b/cases/file_to_tcp_performance/ansible/reset.yml
@@ -1,15 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: vector
+    - role: subjects
       action: reset
 
 - hosts: '{{ test_namespace }}:&tag_TestRole_consumer'
@@ -18,4 +10,4 @@
     - role: logstash
       action: reset
     - role: tcp_test_server
-      action: stop
+      action: reset

--- a/cases/file_truncate_correctness/ansible/reset.yml
+++ b/cases/file_truncate_correctness/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset

--- a/cases/regex_parsing_performance/ansible/reset.yml
+++ b/cases/regex_parsing_performance/ansible/reset.yml
@@ -1,21 +1,11 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    # - role: fluentbit
-    #   action: reset
-    # - role: fluentd
-    #   action: stop
-    # - role: logstash
-    #   action: reset
-    # - role: splunk_heavy_forwarder
-    #   action: reset
-    # - role: telegraf
-    #   action: reset
-    - role: vector
+    - role: subjects
       action: reset
 
 - hosts: '{{ test_namespace }}:&tag_TestRole_consumer'
   become: true
   roles:
     - role: tcp_test_server
-      action: stop
+      action: reset

--- a/cases/sighup_correctness/ansible/reset.yml
+++ b/cases/sighup_correctness/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset

--- a/cases/tcp_to_blackhole_performance/ansible/reset.yml
+++ b/cases/tcp_to_blackhole_performance/ansible/reset.yml
@@ -1,11 +1,5 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: vector
+    - role: subjects
       action: reset

--- a/cases/tcp_to_http_performance/ansible/reset.yml
+++ b/cases/tcp_to_http_performance/ansible/reset.yml
@@ -1,17 +1,11 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: vector
+    - role: subjects
       action: reset
 
 - hosts: '{{ test_namespace }}:&tag_TestRole_consumer'
   become: true
   roles:
     - role: http_test_server
-      action: stop
+      action: reset

--- a/cases/tcp_to_tcp_performance/ansible/reset.yml
+++ b/cases/tcp_to_tcp_performance/ansible/reset.yml
@@ -1,19 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
-      action: reset
-    - role: splunk_heavy_forwarder
-      action: reset
-    - role: splunk_universal_forwarder
-      action: reset
-    - role: vector
+    - role: subjects
       action: reset
 
 - hosts: '{{ test_namespace }}:&tag_TestRole_consumer'
@@ -22,4 +10,4 @@
     - role: logstash
       action: reset
     - role: tcp_test_server
-      action: stop
+      action: reset

--- a/cases/wrapped_json_correctness/ansible/reset.yml
+++ b/cases/wrapped_json_correctness/ansible/reset.yml
@@ -1,15 +1,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_subject'
   become: true
   roles:
-    - role: filebeat
-      action: stop
-    - role: fluentbit
-      action: reset
-    - role: fluentd
-      action: stop
-    - role: logstash
+    - role: subjects
       action: reset
     - role: test_servers
-      action: stop
-    - role: vector
       action: reset


### PR DESCRIPTION
This change creates a new `subjects` role that performance tasks across all subjects. A new task called `save_facts.yml` is available which uses the `subject_versions.fact` template, saving it in the `/etc/ansible/facts.d` directory.