### PR TITLE
Update vector config for new versions

### DIFF
--- a/ansible/roles/vector/templates/output_for_summary.toml
+++ b/ansible/roles/vector/templates/output_for_summary.toml
@@ -1,4 +1,5 @@
 [sinks.out]
   inputs  = ["{{ input_id }}"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ tcp_consumer_port }}"

--- a/cases/disk_buffer_performance/ansible/config_files/vector.toml
+++ b/cases/disk_buffer_performance/ansible/config_files/vector.toml
@@ -1,12 +1,14 @@
 data_dir = "/var/lib/vector"
 
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "0.0.0.0:{{ subject_port }}"
 
 [sinks.out]
   inputs  = ["in"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "{{ consumer_instance.ec2_private_ip_address }}:{{ consumer_port }}"
 
   [sinks.out.buffer]

--- a/cases/disk_buffer_persistence_correctness/ansible/config_files/vector.toml
+++ b/cases/disk_buffer_persistence_correctness/ansible/config_files/vector.toml
@@ -1,12 +1,14 @@
 data_dir = "/var/lib/vector"
 
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ subject_port }}"
 
 [sinks.out]
   inputs  = ["in"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ tcp_consumer_port }}"
 
   [sinks.out.buffer]

--- a/cases/file_rotate_create_correctness/ansible/config_files/vector.toml
+++ b/cases/file_rotate_create_correctness/ansible/config_files/vector.toml
@@ -10,6 +10,7 @@ data_dir = "/var/lib/vector"
 
 [sinks.out]
   inputs   = ["in"]
-  type     = "tcp"
+  type     = "socket"
+  mode     = "tcp"
   address  = "127.0.0.1:{{ tcp_consumer_port }}"
   encoding = "text"

--- a/cases/file_rotate_truncate_correctness/ansible/config_files/vector.toml
+++ b/cases/file_rotate_truncate_correctness/ansible/config_files/vector.toml
@@ -10,6 +10,7 @@ data_dir = "/var/lib/vector"
 
 [sinks.out]
   inputs   = ["in"]
-  type     = "tcp"
+  type     = "socket"
+  mode     = "tcp"
   address  = "127.0.0.1:{{ tcp_consumer_port }}"
   encoding = "text"

--- a/cases/file_to_tcp_performance/ansible/config_files/vector.toml
+++ b/cases/file_to_tcp_performance/ansible/config_files/vector.toml
@@ -5,5 +5,6 @@
 
 [sinks.out]
   inputs  = ["in"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "{{ consumer_instance.ec2_private_ip_address }}:{{ consumer_port }}"

--- a/cases/file_truncate_correctness/ansible/config_files/vector.toml
+++ b/cases/file_truncate_correctness/ansible/config_files/vector.toml
@@ -5,5 +5,6 @@
 
 [sinks.out]
   inputs  = ["in"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ tcp_consumer_port }}"

--- a/cases/regex_parsing_performance/ansible/config_files/vector.toml
+++ b/cases/regex_parsing_performance/ansible/config_files/vector.toml
@@ -1,5 +1,6 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "0.0.0.0:{{ subject_port }}"
 
 [transforms.apache_common_parser]
@@ -9,5 +10,6 @@
 
 [sinks.out]
   inputs  = ["apache_common_parser"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "{{ consumer_instance.ec2_private_ip_address }}:{{ consumer_port }}"

--- a/cases/sighup_correctness/ansible/config_files/vector.toml
+++ b/cases/sighup_correctness/ansible/config_files/vector.toml
@@ -1,8 +1,10 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ subject_port }}"
 
 [sinks.out]
   inputs  = ["in"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "{{ consumer_instance.ec2_private_ip_address }}:{{ consumer_port }}"

--- a/cases/tcp_to_blackhole_performance/ansible/config_files/vector.toml
+++ b/cases/tcp_to_blackhole_performance/ansible/config_files/vector.toml
@@ -1,5 +1,6 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "0.0.0.0:{{ subject_port }}"
 
 [sinks.out]

--- a/cases/tcp_to_http_performance/ansible/config_files/vector.toml
+++ b/cases/tcp_to_http_performance/ansible/config_files/vector.toml
@@ -1,5 +1,6 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "0.0.0.0:{{ subject_port }}"
 
 [sinks.out]

--- a/cases/tcp_to_tcp_performance/ansible/config_files/vector.toml
+++ b/cases/tcp_to_tcp_performance/ansible/config_files/vector.toml
@@ -1,9 +1,11 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "0.0.0.0:{{ subject_port }}"
 
 [sinks.out]
   inputs   = ["in"]
-  type     = "tcp"
+  type     = "socket"
+  mode     = "tcp"
   address  = "{{ consumer_instance.ec2_private_ip_address }}:{{ consumer_port }}"
   encoding = "text"

--- a/cases/wrapped_json_correctness/ansible/config_files/vector.toml
+++ b/cases/wrapped_json_correctness/ansible/config_files/vector.toml
@@ -1,5 +1,6 @@
 [sources.in]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ subject_port }}"
 
 [transforms.json_decoder]
@@ -13,5 +14,6 @@
 
 [sinks.out]
   inputs  = ["json_unwrapper"]
-  type    = "tcp"
+  type    = "socket"
+  mode    = "tcp"
   address = "127.0.0.1:{{ tcp_consumer_port }}"


### PR DESCRIPTION
Not sure if that's everything, but with this at least `tcp_to_tcp_performance` passes.