### PR TITLE
Use AWS_DEFAULT_REGION if AWS_REGION is not set

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -216,7 +216,7 @@ if [ "$BOOTSTRAP" == 'true' ] && [ "$SKIP_TERRAFORM" != 'true' ]; then
   terraform init \
     "${TERRAFORM_COMMON_EXTRA_ARGS[@]}" \
     -backend-config="bucket=vector-test-harness-state" \
-    -backend-config="region=$AWS_REGION" \
+    -backend-config="region=${AWS_REGION:-$AWS_DEFAULT_REGION}" \
     -backend-config="encrypt=true" \
     -backend-config="dynamodb_table=TerraformLocks" \
     -backend-config="key=vector-test-case/$TEST_NAME/$TEST_CONFIGURATION/$TEST_USER_ID.tfstate" \


### PR DESCRIPTION
This PR makes the test harness to switch to using `AWS_DEFAULT_REGION` instead of `AWS_REGION` if the latter is not set.