### PR TITLE
Use name of the bucket used to store the state from an environment variable

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -17,5 +17,7 @@ export VECTOR_TEST_SSH_PUBLIC_KEY=~/.ssh/vector_tests.pub
 # user_id. Ex: ben
 export VECTOR_TEST_USER_ID=<REPLACE_ME>
 
+# The S3 bucket used to store state of the test infrastructure.
+export VECTOR_TEST_STATE_S3_BUCKET_NAME=<REPLACE ME>
 # The S3 bucket used to store test results.
 export VECTOR_TEST_RESULTS_S3_BUCKET_NAME=<REPLACE_ME>

--- a/bin/test
+++ b/bin/test
@@ -215,7 +215,7 @@ if [ "$BOOTSTRAP" == 'true' ] && [ "$SKIP_TERRAFORM" != 'true' ]; then
 
   terraform init \
     "${TERRAFORM_COMMON_EXTRA_ARGS[@]}" \
-    -backend-config="bucket=vector-test-harness-state" \
+    -backend-config="bucket=${VECTOR_TEST_STATE_S3_BUCKET_NAME}" \
     -backend-config="region=$AWS_REGION" \
     -backend-config="encrypt=true" \
     -backend-config="dynamodb_table=TerraformLocks" \


### PR DESCRIPTION
This PR makes it possible to specify a custom name for the bucket used to store the state.