### PR TITLE
Updates to configuration to fix a few issues discovered while running

### DIFF
--- a/ansible/roles/vector/tasks/install.yml
+++ b/ansible/roles/vector/tasks/install.yml
@@ -7,6 +7,12 @@
         name: vector
         state: absent
 
+    - name: Ensure vector user is removed before installing
+      user:
+        name: vector
+        state: absent
+        remove: yes
+
     - name: Install Vector .deb package from URL
       when: vector_version is not regex('^dev-')
       include: "install_deb_from_url.yml"

--- a/bin/teardown
+++ b/bin/teardown
@@ -20,6 +20,7 @@ OPTIONS
    -c, --configuration   The test configuration (default: default, env: VECTOR_TEST_CONFIGURATION)
    -t, --test            The test to run (ex: tcp_to_blackhole, env: VECTOR_TEST_NAME)
    -u, --user-id         Your user ID (ex: ben, env: VECTOR_TEST_USER_ID)
+   -y, --yes             Answer yes to any prompts
    -h, --help            Print this message
 
 EXAMPLE
@@ -44,13 +45,14 @@ TEST_NAME="${VECTOR_TEST_NAME:-""}"
 TEST_RESULTS_S3_BUCKET_NAME="${VECTOR_TEST_RESULTS_S3_BUCKET_NAME:-""}"
 TEST_SSH_PUBLIC_KEY="${VECTOR_TEST_SSH_PUBLIC_KEY:-""}"
 TEST_USER_ID="${VECTOR_TEST_USER_ID:-""}"
+TEST_YES_PROMPTS="${VECTOR_TEST_YES_PROMPTS:-""}"
 
 #
 # Flags
 #
 
-OPTIONS="c:t:u:h"
-LONGOPTS="configuration:,test:,user-id:,help"
+OPTIONS="c:t:u:yh"
+LONGOPTS="configuration:,test:,user-id:,yes,help"
 PARSED="$(parse_arguments "$OPTIONS" "$LONGOPTS" "$0" "$@")"
 eval set -- "$PARSED"
 
@@ -67,6 +69,14 @@ while true; do
   -u | --user-id)
     TEST_USER_ID="$2"
     shift 2
+    ;;
+  -u | --user-id)
+    TEST_USER_ID="$2"
+    shift 2
+    ;;
+  -y | --yes)
+    TEST_YES_PROMPTS=true
+    shift 1
     ;;
   -h | --help)
     usage
@@ -132,6 +142,7 @@ export TF_IN_AUTOMATION=true
 export TF_DATA_DIR=".terraform/$TEST_CONFIGURATION/$TEST_USER_ID"
 terraform destroy \
   "${TERRAFORM_COMMON_EXTRA_ARGS[@]}" \
+  "$(if [[ $TEST_YES_PROMPTS ]]; then echo "--auto-approve"; fi)" \
   -var pub_key="$TEST_SSH_PUBLIC_KEY" \
   -var test_name="$TEST_NAME" \
   -var test_configuration="$TEST_CONFIGURATION" \

--- a/bin/test
+++ b/bin/test
@@ -213,7 +213,7 @@ if [ "$BOOTSTRAP" == 'true' ] && [ "$SKIP_TERRAFORM" != 'true' ]; then
   export TF_IN_AUTOMATION=true
   export TF_DATA_DIR=".terraform/$TEST_CONFIGURATION/$TEST_USER_ID"
 
-  terraform init -reconfigure \
+  terraform init \
     "${TERRAFORM_COMMON_EXTRA_ARGS[@]}" \
     -backend-config="bucket=${VECTOR_TEST_STATE_S3_BUCKET_NAME}" \
     -backend-config="region=${AWS_DEFAULT_REGION}" \

--- a/cases/disk_buffer_performance/ansible/run.yml
+++ b/cases/disk_buffer_performance/ansible/run.yml
@@ -29,7 +29,7 @@
 - hosts: '{{ test_namespace }}:&tag_TestRole_producer'
   become: true
   tasks:
-    - name: Wait for port {{ subject_port }} to become available
+    - name: Wait for subject {{ subject_ip }}:{{ subject_port }} to become available
       wait_for:
         host: "{{ subject_ip }}"
         port: "{{ subject_port }}"
@@ -38,7 +38,7 @@
     - name: Warmup {{ test_subject }}
       shell: |
         socat_loop 10 /tmp/flog-100MiB.log \
-          -u - tcp:{{ hostvars[groups.tag_TestRole_subject.0].private_ip_address }}:{{ subject_port }}
+          -u - tcp:{{ subject_ip }}:{{ subject_port }}
       register: timeout
       failed_when: timeout.rc != 124
 
@@ -57,7 +57,7 @@
     - name: Pipe test data to {{ test_subject }}
       shell: |
         socat_loop 60 /tmp/flog-100MiB.log \
-          -u - tcp:{{ hostvars[groups.tag_TestRole_subject.0].private_ip_address }}:{{ subject_port }}
+          -u - tcp:{{ subject_ip }}:{{ subject_port }}
       register: timeout
       failed_when: timeout.rc != 124
 

--- a/cases/disk_buffer_performance/terraform/.terraform.lock.hcl
+++ b/cases/disk_buffer_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/file_to_tcp_performance/terraform/.terraform.lock.hcl
+++ b/cases/file_to_tcp_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/lua_base_performance/terraform/.terraform.lock.hcl
+++ b/cases/lua_base_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/real_world_1_performance/terraform/.terraform.lock.hcl
+++ b/cases/real_world_1_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/regex_parsing_performance/terraform/.terraform.lock.hcl
+++ b/cases/regex_parsing_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/tcp_to_blackhole_performance/terraform/.terraform.lock.hcl
+++ b/cases/tcp_to_blackhole_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/tcp_to_http_performance/terraform/.terraform.lock.hcl
+++ b/cases/tcp_to_http_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/cases/tcp_to_tcp_performance/terraform/.terraform.lock.hcl
+++ b/cases/tcp_to_tcp_performance/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = "~> 3.11"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}


### PR DESCRIPTION
This includes a few fixes for issues I discovered while trying to run
the test harness tests the past couple of days.

* Use subject_ip for disk_buffer_performance cases. Matches other test
  cases. The existing hostvars seemed to be pulling a different IP;
  I think because it wasn't filtering enough (just on role).
* Remove --reconfigure from bin/test. This only needs to be done in unusual circumstances.
* Remove the vector user after uninstalling the package. A regression
  was introduced, fixed by https://github.com/timberio/vector/pull/5921,
  where new packages couldn't install due to the user already existing.
* Adds Terraform lock files
* Adds `-y` flag to `./bin/teardown` to suppress Terraform prompt

Fixes https://github.com/timberio/vector-test-harness/issues/64

There is still the issue of the asset rename, but I think I'm going to resolve that through S3 redirects so I didn't push the local change.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>