### PR TITLE
Fix wrapped_json_correctness: replace removed json_parser with remap

### DIFF
--- a/cases/wrapped_json_correctness/ansible/config_files/vector.toml
+++ b/cases/wrapped_json_correctness/ansible/config_files/vector.toml
@@ -3,17 +3,18 @@
   mode    = "tcp"
   address = "127.0.0.1:{{ subject_port }}"
 
-[transforms.json_decoder]
-  inputs  = ["in"]
-  type    = "json_parser"
-
-[transforms.json_unwrapper]
-  inputs  = ["json_decoder"]
-  type    = "json_parser"
-  field   = "log"
+[transforms.parse_wrapped_json]
+  inputs = ["in"]
+  type   = "remap"
+  source = '''
+    . = merge!(., parse_json!(string!(.message)))
+    . = merge!(., parse_json!(string!(.log)))
+    del(.log)
+  '''
 
 [sinks.out]
-  inputs  = ["json_unwrapper"]
-  type    = "socket"
-  mode    = "tcp"
-  address = "127.0.0.1:{{ tcp_consumer_port }}"
+  inputs         = ["parse_wrapped_json"]
+  type           = "socket"
+  mode           = "tcp"
+  address        = "127.0.0.1:{{ tcp_consumer_port }}"
+  encoding.codec = "json"


### PR DESCRIPTION
## Summary

- `json_parser` was removed in modern Vector; this test was broken as a result
- Replaced two chained `json_parser` transforms with a single `remap` transform using VRL
- Added explicit `encoding.codec = "json"` to the socket sink (previously implicit in old Vector, now required)

## What the test verifies

Vector correctly double-parses a wrapped JSON envelope — outer JSON decoded, then the `log` field (itself a JSON string) decoded into the event root — producing `message: "Hello world"` from input `{"log":"{\"message\":\"Hello world\"}"}`. This pattern is important for Docker/Kubernetes log pipelines.

## Changes

`cases/wrapped_json_correctness/ansible/config_files/vector.toml`

- Removed: `json_decoder` and `json_unwrapper` transforms (`type = "json_parser"`)
- Added: single `parse_wrapped_json` remap transform with equivalent VRL logic
- Added: `encoding.codec = "json"` on the sink

## Test plan

- [x] `vector validate --no-environment` passes on the updated config
- [x] Local end-to-end smoke test: sent test payload via TCP, confirmed output `message == "Hello world"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)